### PR TITLE
Add string representation for drone odometry

### DIFF
--- a/mavlink/modules/drone_odometry.py
+++ b/mavlink/modules/drone_odometry.py
@@ -46,6 +46,12 @@ class DronePosition:
         self.longitude = longitude
         self.altitude = altitude
 
+    def __str__(self) -> str:
+        """
+        To string.
+        """
+        return f"{self.__class__}, latitude: {self.latitude}, longitude: {self.longitude}, altitude: {self.altitude}"
+
 
 class DroneOrientation:
     """
@@ -96,6 +102,12 @@ class DroneOrientation:
         self.pitch = pitch
         self.roll = roll
 
+    def __str__(self) -> str:
+        """
+        To string.
+        """
+        return f"{self.__class__}, yaw: {self.yaw}, pitch: {self.pitch}, roll: {self.roll}"
+
 
 class DroneOdometry:
     """
@@ -132,3 +144,9 @@ class DroneOdometry:
 
         self.position = position
         self.orientation = orientation
+
+    def __str__(self) -> str:
+        """
+        To string.
+        """
+        return f"{self.__class__}, position: {self.position}, orientation: {self.orientation}"


### PR DESCRIPTION
## Add string representation for drone odometry

**Key Changes**
* Wrote the to string function for the following classes
  * `DronePosition`
  * `DroneOrientation`
  * `DroneOdometry`

**Why are the changes needed?**
* When we log the `home_location` in `computer-vision-python` they can be logged nicely with the string representation. 