### PR TITLE
Added Baud Rate Parameter and Default Baud Rate to `FlightController`

### DIFF
--- a/mavlink/modules/flight_controller.py
+++ b/mavlink/modules/flight_controller.py
@@ -20,15 +20,16 @@ class FlightController:
     __MAVLINK_LANDING_COMMAND = dronekit.mavutil.mavlink.MAV_CMD_NAV_LAND
 
     @classmethod
-    def create(cls, address: str) -> "tuple[bool, FlightController | None]":
+    def create(cls, address: str, baud: int = 57600) -> "tuple[bool, FlightController | None]":
         """
         address: TCP address or serial port of the drone (e.g. "tcp:127.0.0.1:14550").
+        baud: Baud rate for the connection (default is 57600).
         Establishes connection to drone through provided address
         and stores the DroneKit object.
         """
         try:
             # Wait ready is false as the drone may be on the ground
-            drone = dronekit.connect(address, wait_ready=False)
+            drone = dronekit.connect(address, wait_ready=False, baud=baud)
         except dronekit.TimeoutError:
             print("No messages are being received. Make sure address/port is a host address/port.")
             return False, None


### PR DESCRIPTION
## Added Baud Rate Parameter and Default Baud Rate to `FlightController`

**Key Changes**
- Added baud rate parameter and set the default to 57600

**Why are these changes needed**
- When testing the airside system with a physical connection, the `FlightController` class was not working because the baud rate the Pixhawk was using was 57600 and the default baud rate for DroneKit was 115200. [Source](https://dronekit-python.readthedocs.io/en/latest/automodule.html#dronekit.connect). 
- This change allows us to change the baud rate to match the baud rate of the Pixhawk.

**Testing**
- Tested the `test_flight_controller.py` script to ensure `FlightController` still works.